### PR TITLE
Removed the container around the yield

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,7 @@
 
   <body>
     <%= render 'shared/navbar' %>
-    <div class="container">
       <%= yield %>
-    </div>
     <%= render "shared/footer" %>
   </body>
 </html>


### PR DESCRIPTION
Fixing the issue with the banner not being full page anymore.
Removed the container around the yield and will add containers in each pages.