### PR TITLE
Set card height to 85%

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -6,6 +6,7 @@
   border-radius: 8px;
   color: black;
   text-decoration: none;
+  height: 85%;
   p {
   font-size: 12px;
   opacity: .7;


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-08-19 at 3 08 54 PM" src="https://user-images.githubusercontent.com/62083493/130130066-bd0abceb-d93d-458c-bb5a-5e10dcd98b10.png">
Set card height to 85%
Please review and comment if you think this look ok or you want the card to be bigger/smaller 