### PR TITLE
Fix price display

### DIFF
--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -12,17 +12,19 @@
         <div class="card-listing">
           <img src=<%=listing.photo%>>
           <div class="card-listing-infos">
-            <div>
-              <h2>
-                <%= listing.name %>
+            <div class="d-flex">
+              <div class="pr-5">
+                <h2>
+                  <%= listing.name %>
+                </h2>
+                <p>
+                  <%= listing.description %>
+                </p>
+              </div>
+              <h2 class="card-listing-pricing pt-3">
+                <%= number_to_currency(listing.price) %> <br>/ day
               </h2>
-              <p>
-                <%= listing.description %>
-              </p>
             </div>
-            <h2 class="card-listing-pricing">
-              <%= number_to_currency(listing.price) %> / day
-            </h2>
             <img src="https://i.pravatar.cc/150?img=<%= index + 1 %>" class="card-listing-user avatar-bordered" />
           </div>
         </div>


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-08-19 at 4 17 12 PM" src="https://user-images.githubusercontent.com/62083493/130137966-b04ea542-fbfb-4a1a-a249-e819dee8e521.png">

- I added flex display for a better alignment.
- Also added <br> so '/day' so that price display looks similiar(?)